### PR TITLE
Load helm-files for using helm-generic-files-map

### DIFF
--- a/helm-bundle-show.el
+++ b/helm-bundle-show.el
@@ -26,6 +26,7 @@
 ;;; Code:
 
 (require 'helm)
+(require 'helm-files)
 
 (defgroup helm-bundle-show nil
   "bundle show with helm interface"


### PR DESCRIPTION
In original code, exception is raised if users load this file before
loading helm-files as below.

```
Load error for /home/syohei/emacs-helm-bundle-show/helm-bundle-show.el:           
(void-variable helm-generic-files-map)
```
